### PR TITLE
Update Docker to Carla 0.95 and Autoware 1.11.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "catkin_ws/src/ros-bridge"]
 	path = catkin_ws/src/ros-bridge
 	url = ../ros-bridge.git
+[submodule "autoware_data"]
+	path = autoware_data
+	url = https://bitbucket.org/carla-simulator/autoware-contents

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ Integration of AutoWare AV software with the CARLA simulator
 
 Setup/build Autoware as described here: https://github.com/CPFL/Autoware
 
-### Download Point cloud maps
-
-    # Download pointcloud maps for Carla Towns
-    cd ~
-    git clone https://bitbucket.org/carla-simulator/autoware-contents
-
 ### Carla
 
     #download docker image (e.g. version 0.9.5)
@@ -38,14 +32,17 @@ Setup/build Autoware as described here: https://github.com/CPFL/Autoware
 
 ### Carla Autoware Bridge
 
-The Carla Autoware Bridge is a ROS package. Therefore we create a catkin workspace (containing all relevant packages).
-The generic Carla ROS bridge (https://github.com/carla-simulator/ros-bridge.git) is included as GIT submodule and 
-has to be initialized ("git submodule update --init") and updated ("git submodule update").
+The Carla Autoware Bridge contains two submodules: the Carla ROS bridge (https://github.com/carla-simulator/ros-bridge.git)
+and point cloud maps for Carla Towns (https://bitbucket.org/carla-simulator/autoware-contents). Clone the repository and 
+initialize the submodules:
 
     cd ~
     git lfs clone https://github.com/carla-simulator/carla-autoware.git
     cd carla-autoware
     git submodule update --init
+
+The Carla Autoware Bridge is a ROS package. Therefore we create a catkin workspace (containing all relevant packages).
+
     cd catkin_ws
     catkin_init_workspace src/
     cd src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,17 +1,18 @@
-ARG CARLA_VERSION=0.9.3
+ARG CARLA_VERSION=0.9.5
 
 FROM nvidia/opengl:1.1-glvnd-runtime-ubuntu16.04 as nvidia-opengl
 FROM carlasim/carla:$CARLA_VERSION as carla
 
-FROM autoware/autoware:1.9.1-kinetic
+FROM autoware/autoware:1.11.0-kinetic-cuda
 
+SHELL ["/bin/bash", "-c"]
 ARG CARLA_VERSION
 
 USER root
 RUN apt-get update \
-	&& apt-get install -y python-pip libpng16-16 python-pygame ros-kinetic-ackermann-msgs ros-kinetic-derived-object-msgs --no-install-recommends \
+	&& apt-get install -y python-pip libpng16-16 ros-kinetic-ackermann-msgs ros-kinetic-derived-object-msgs --no-install-recommends \
 	&& rm -rf /var/lib/apt/lists/*
-RUN pip install simple-pid
+RUN pip install simple-pid pygame networkx==2.2
 
 COPY --from=nvidia-opengl /usr/local/lib/x86_64-linux-gnu /usr/local/lib/x86_64-linux-gnu
 COPY --from=nvidia-opengl /usr/local/lib/i386-linux-gnu /usr/local/lib/i386-linux-gnu
@@ -27,20 +28,24 @@ ENV NVIDIA_DRIVER_CAPABILITIES \
 ENV LD_LIBRARY_PATH /usr/local/lib/x86_64-linux-gnu:/usr/local/lib/i386-linux-gnu${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
 
 COPY --from=carla --chown=autoware /home/carla/PythonAPI home/$USERNAME/carla-autoware/PythonAPI
-ENV PYTHONPATH=/home/$USERNAME/carla-autoware/PythonAPI/carla-$CARLA_VERSION-py2.7-linux-x86_64.egg:/home/$USERNAME/carla-autoware/PythonAPI
+ENV PYTHONPATH=/home/$USERNAME/carla-autoware/PythonAPI/carla/dist/carla-$CARLA_VERSION-py2.7-linux-x86_64.egg:/home/$USERNAME/carla-autoware/PythonAPI/carla
 
 USER autoware
 
 RUN cd && mkdir -p /home/$USERNAME/carla-autoware
 COPY --chown=autoware catkin_ws /home/$USERNAME/carla-autoware/catkin_ws
 
-RUN /bin/bash -c 'source /home/$USERNAME/Autoware/ros/devel/setup.bash; cd /home/$USERNAME/carla-autoware/catkin_ws/src; catkin_init_workspace; cd ../; catkin_make -DCMAKE_BUILD_TYPE=Release'
+RUN source /etc/profile.d/ros.sh; source /home/autoware/Autoware/ros/install/local_setup.bash; \
+    cd /home/$USERNAME/carla-autoware/catkin_ws/src; catkin_init_workspace; cd ../; \
+    catkin_make -DCMAKE_BUILD_TYPE=Release
 
 COPY --chown=autoware autoware_data /home/$USERNAME/carla-autoware/autoware_data
 COPY --chown=autoware autoware_launch /home/$USERNAME/carla-autoware/autoware_launch
 COPY --chown=autoware docker/param.yaml /home/$USERNAME/Autoware/ros/src/util/packages/runtime_manager/scripts/param.yaml
 
-ENV CARLA_AUTOWARE_ROOT=/home/$USERNAME/carla-autoware
-
-RUN echo "source /home/$USERNAME/carla-autoware/catkin_ws/devel/setup.bash" >> /home/$USERNAME/.bashrc
-
+RUN echo $'export CARLA_AUTOWARE_ROOT=/home/$USERNAME/carla-autoware/autoware_launch \n\
+           export CARLA_MAPS_PATH=/home/$USERNAME/carla-autoware/autoware_data/maps \n\
+           source /home/$USERNAME/Autoware/ros/install/setup.bash \n\
+           source /home/$USERNAME/carla-autoware/catkin_ws/devel/setup.bash \n' \
+           >> /home/$USERNAME/.bashrc
+RUN echo "export PYTHONPATH=\$PYTHONPATH:${PYTHONPATH}" >> /home/$USERNAME/.bashrc

--- a/docker/README.md
+++ b/docker/README.md
@@ -22,7 +22,7 @@ These commands will create a "carla-autoware:latest" Docker image.
 ### Run image
 Please consult the main README regarding execution of Carla, the Carla Autoware Bridge and the
 Autoware stack.
-Start Carla server and client as described there (Terminals 1 and 2).
+Start Carla server as described there (Terminal 1 and 2).
 
 The bridge and the Autoware stack have to be executed within the Docker container (the
 Terminal 3 steps).
@@ -32,8 +32,7 @@ Start the container:
    ./run.sh
 
 Within the Docker shell:
-    Autoware/ros/run
-    roslaunch carla_autoware_bridge carla_autoware_bridge.launch
+    roslaunch $CARLA_AUTOWARE_ROOT/devel.launch
 
 Then follow the remaining steps from main README, especially the ones within Autoware Runtime Manager.
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 usage() { echo "Usage: $0 [-t <tag>] [-r <repo>] [-s <Shared directory>]" 1>&2; exit 1; }
 
@@ -51,7 +51,6 @@ then
     chmod a+r $XAUTH
 fi
 
-
 docker run -it --rm \
     --runtime=nvidia \
     --volume=$XAUTH:$XAUTH:rw \
@@ -60,6 +59,7 @@ docker run -it --rm \
     --env="XAUTHORITY=$XAUTH" \
     --env="DISPLAY=$DISPLAY" \
     --env="QT_X11_NO_MITSHM=1" \
+    --env="USER_ID=${UID}" \
     -u autoware \
     --net=host \
     $DOCKER_HUB_REPO:$TAG


### PR DESCRIPTION
Dockerfile Autoware version was out of sync with the rest of this codebase. In particular, I received from inside the built Docker image:

```
$ roslaunch carla-autoware/autoware_launch/devel.launch
... logging to /home/autoware/.ros/log/6dcf7616-5d9d-11e9-a2cb-1831bf6d3e6f/roslaunch-platypus-512.log                                                                                                
Checking log directory for disk usage. This may take awhile.                                                                                                                                          
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.                                                                                                                                                     
                                                                                                                                                                                                      
Traceback (most recent call last):                                                                                                                                                                    
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/__init__.py", line 306, in main
    p.start()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/parent.py", line 268, in start
    self._start_infrastructure()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/parent.py", line 217, in _start_infrastructure
    self._load_config()
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/parent.py", line 132, in _load_config
    roslaunch_strs=self.roslaunch_strs, verbose=self.verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/config.py", line 451, in load_config_default
    loader.load(f, config, verbose=verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 749, in load
    self._load_launch(launch, ros_config, is_core=core, filename=filename, argv=argv, verbose=verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 721, in _load_launch
    self._recurse_load(ros_config, launch.childNodes, self.root_context, None, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 685, in _recurse_load
    val = self._include_tag(tag, context, ros_config, default_machine, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 95, in call
    return f(*args, **kwds)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 627, in _include_tag
    default_machine, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 685, in _recurse_load
    val = self._include_tag(tag, context, ros_config, default_machine, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 95, in call
    return f(*args, **kwds)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 627, in _include_tag
    default_machine, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 685, in _recurse_load
    val = self._include_tag(tag, context, ros_config, default_machine, is_core, verbose)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 95, in call
    return f(*args, **kwds)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 589, in _include_tag
    inc_filename = self.resolve_args(tag.attributes['file'].value, context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 183, in resolve_args
    return substitution_args.resolve_args(args, context=context.resolve_dict, resolve_anon=self.resolve_anon)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 370, in resolve_args
    resolved = _resolve_args(resolved, context, resolve_anon, commands)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 383, in _resolve_args
    resolved = commands[command](resolved, a, args, context)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 151, in _find
    source_path_to_packages=source_path_to_packages)
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 197, in _find_executable
    full_path = _get_executable_path(rp.get_path(args[0]), path)
  File "/usr/lib/python2.7/dist-packages/rospkg/rospack.py", line 203, in get_path
    raise ResourceNotFound(name, ros_paths=self._ros_paths)
ResourceNotFound: vehicle_description
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/home/autoware/carla-autoware/catkin_ws/src
ROS path [2]=/home/autoware/Autoware/ros/src
ROS path [3]=/opt/ros/kinetic/share
```
 
This appears to be because `vehicle_description` did not exist in Autoware 1.9.1.

Accordingly, I've updated the Dockerfile to work with the latest version of `carla-autoware`, Carla 0.95 and Autoware 1.11.0.

I've also clarified the README and added `autoware_data` as a submodule in the directory assumed by the `Dockerfile`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla-autoware/37)
<!-- Reviewable:end -->
