### PR TITLE
Update Readme, clarification of the clone process

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The easiest way to run the agent is by building and running the provided docker 
 
 ### Setup
 
-Firstly clone the carla autoware repository alongside the needed [autoware contents](https://bitbucket.org/carla-simulator/autoware-contents.git):
+Firstly clone the carla autoware repository, where additional [autoware contents](https://bitbucket.org/carla-simulator/autoware-contents.git) are included as a submodule:
 
 ```sh
 git clone --recurse-submodules https://github.com/carla-simulator/carla-autoware


### PR DESCRIPTION
Minor update to the documentation. I got confused by the phrasing "cloning additional autoware contents alongside", whereas I just had to `--recurse-submodule`. I hoped that this might help others.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/carla-autoware/96)
<!-- Reviewable:end -->
